### PR TITLE
Statically check for args before trying to use format

### DIFF
--- a/source/tkd/interpreter/tcl.d
+++ b/source/tkd/interpreter/tcl.d
@@ -120,7 +120,12 @@ class Tcl
 
 		debug (log) this._log.eval(script, args);
 
-		int result = Tcl_EvalEx(this._interpreter, format(script, args).toStringz, -1, 0);
+		static if (A.length)		
+			auto cmd = format(script, args);		
+		else		
+			auto cmd = script;		
+
+		int result = Tcl_EvalEx(this._interpreter, cmd.toStringz, -1, 0);
 
 		if (result == TCL_ERROR)
 		{


### PR DESCRIPTION
Something like this is needed in cases where the caller has already formatted the eval string, but that formatted string still contains format specifiers, ie:

```
auto text = "{ %s %s %s }";
this._tk.eval(`%s insert end "%s"`.format(this.id, escape(text)));
```