### PR TITLE
Statically check for args before trying to use format

### DIFF
--- a/source/tkd/interpreter/logger.d
+++ b/source/tkd/interpreter/logger.d
@@ -148,7 +148,12 @@ class Logger
 	{
 		try
 		{
-			this.log(format(text, args), Level.eval);
+			static if (A.length)
+				auto cmd = format(text, args);
+			else
+				auto cmd = text;
+
+			this.log(cmd, Level.eval);
 		}
 		catch (Exception ex)
 		{

--- a/source/tkd/interpreter/tcl.d
+++ b/source/tkd/interpreter/tcl.d
@@ -120,7 +120,12 @@ class Tcl
 
 		debug (log) this._log.eval(script, args);
 
-		int result = Tcl_EvalEx(this._interpreter, format(script, args).toStringz, -1, 0);
+		static if (A.length)		
+			auto cmd = format(script, args);		
+		else		
+			auto cmd = script;		
+
+		int result = Tcl_EvalEx(this._interpreter, cmd.toStringz, -1, 0);
 
 		if (result == TCL_ERROR)
 		{


### PR DESCRIPTION
As before, I don't know if this is *actually* what you want to do, but something like it is needed to avoid the orphan format specifier thing. 