### PR TITLE
Escaping problems with tcl's list command, and more orphan format issues

### DIFF
--- a/source/tkd/widget/treeview.d
+++ b/source/tkd/widget/treeview.d
@@ -429,7 +429,7 @@ class TreeView : Widget, IXScrollable!(TreeView), IYScrollable!(TreeView)
 	 */
 	public auto updateDataColumn(this T)(string rowId, uint columnIndex, string value)
 	{
-		auto cmd = text(this.id, ` set `, rowId, columnIndex, `"`, value, `"`);
+		auto cmd = text(this.id, ` set `, rowId, ` `, columnIndex, ` "`, this._tk.escape(value), `"`);
 		this._tk.eval(cmd);
 
 		return cast(T) this;

--- a/source/tkd/widget/treeview.d
+++ b/source/tkd/widget/treeview.d
@@ -11,6 +11,7 @@ module tkd.widget.treeview;
  */
 import std.algorithm;
 import std.array;
+import std.conv;
 import std.regex;
 import std.string;
 import tkd.element.color;
@@ -389,7 +390,7 @@ class TreeView : Widget, IXScrollable!(TreeView), IYScrollable!(TreeView)
 
 			if (row.values.length > 1)
 			{
-				values = "-values " ~ format(`[list "%s"]`, row.values[1 .. $].join(`" "`));
+				values = "-values " ~ format(`{"%s"}`, row.values[1 .. $].join(`" "`));
 			}
 
 			row._tags = this._tk.escape(row._tags);
@@ -401,7 +402,8 @@ class TreeView : Widget, IXScrollable!(TreeView), IYScrollable!(TreeView)
 
 			// String concatentation is used here to avoid the character 
 			// escaping done on args.
-			this._tk.eval(`%s insert {%s} end -text "` ~  row.values[0] ~ `" ` ~ values ~ ` -open %s ` ~ tags, this.id, parentRow, row.isOpen);
+			auto cmd = text(this.id, ` insert {`, parentRow, `} end -text "`, row.values[0], `" `, values, ` -open `, row.isOpen);
+			this._tk.eval(cmd);
 
 			row._rowId = this._tk.getResult!(string);
 
@@ -427,7 +429,8 @@ class TreeView : Widget, IXScrollable!(TreeView), IYScrollable!(TreeView)
 	 */
 	public auto updateDataColumn(this T)(string rowId, uint columnIndex, string value)
 	{
-		this._tk.eval("%s set %s %s {%s}", this.id, rowId, columnIndex, value);
+		auto cmd = text(this.id, ` set `, rowId, columnIndex, `"`, value, `"`);
+		this._tk.eval(cmd);
 
 		return cast(T) this;
 	}


### PR DESCRIPTION
There are still a few issues with text escaping and stuff. Tcl's ```list``` does its own escaping, so trying to set a column value to e.g. "[1,2,3]" shows up as "\\[1,2,3\\]". Replacing ```[list "%s"]``` with ```{"%s"}``` seems to work, but I don't know why, I'm not good with tcl, it might just be a coincidence. 

The other problem was that the final command was still going through format, so orphan format specs were an issue. Pretty much any command that includes literal text has to be eval'd without going through format (or you could catch FormatExceptions and ignore them...).

This pull fixes just the couple of issues I've found in treeview. I can submit more for other places where this happens if this is the way you want to handle it. Feels a bit brittle though. 