### PR TITLE
Changed setCoords parameter type.

### DIFF
--- a/source/tkd/widget/canvas.d
+++ b/source/tkd/widget/canvas.d
@@ -666,7 +666,7 @@ protected abstract class CanvasItem : Element
 	 * Returns:
 	 *     This item to aid method chaining.
 	 */
-	public auto setCoords(this T)(int[] coords)
+	public auto setCoords(this T)(double[] coords)
 	{
 		assert(coords.length >= 2, "Not enough coordinates specified.");
 


### PR DESCRIPTION
With coords having type int[], passing an argument of type double[] fails to compile from the type mismatch, but it also fails to compile when passed an int[], since it can't implicitly convert the int[] to a double[] when assigning to the _coords member.
For example, using either the second or third lines below was causing an error.
```
auto line = new CanvasLine([0.0, 0.0, 9.0, 9.0]);
line.setCoords([0.0, 0.0, 9.0, 9.0]);
line.setCoords([0, 0, 9, 9]);
```