### PR TITLE
added color options for entry, text, spinbox, combobox, label, window and font options for text

### DIFF
--- a/source/example/example.d
+++ b/source/example/example.d
@@ -206,6 +206,7 @@ class Application : TkdApplication
 				.appendText("import std.stdio;\n\nvoid main(string[] args)\n{\n\twriteln(\"Hello World!\");\n}")
 				.setForegroundColor("#00ff00")
 				.setBackgroundColor("#000000")
+				.setFont("Helvetica")
 				.pack(5, 0, GeometrySide.bottom, GeometryFill.both, AnchorPosition.northWest, true);
 			this._entry = new Entry(entryLabelFrame)
 				.pack(5, 0, GeometrySide.left, GeometryFill.x, AnchorPosition.northWest, true);

--- a/source/example/example.d
+++ b/source/example/example.d
@@ -204,6 +204,8 @@ class Application : TkdApplication
 				.setWidth(0)
 				.setHeight(3)
 				.appendText("import std.stdio;\n\nvoid main(string[] args)\n{\n\twriteln(\"Hello World!\");\n}")
+				.setForegroundColor("#00ff00")
+				.setBackgroundColor("#000000")
 				.pack(5, 0, GeometrySide.bottom, GeometryFill.both, AnchorPosition.northWest, true);
 			this._entry = new Entry(entryLabelFrame)
 				.pack(5, 0, GeometrySide.left, GeometryFill.x, AnchorPosition.northWest, true);

--- a/source/example/example.d
+++ b/source/example/example.d
@@ -204,9 +204,6 @@ class Application : TkdApplication
 				.setWidth(0)
 				.setHeight(3)
 				.appendText("import std.stdio;\n\nvoid main(string[] args)\n{\n\twriteln(\"Hello World!\");\n}")
-				.setForegroundColor("#00ff00")
-				.setBackgroundColor("#000000")
-				.setFont("Helvetica")
 				.pack(5, 0, GeometrySide.bottom, GeometryFill.both, AnchorPosition.northWest, true);
 			this._entry = new Entry(entryLabelFrame)
 				.pack(5, 0, GeometrySide.left, GeometryFill.x, AnchorPosition.northWest, true);

--- a/source/tkd/element/font.d
+++ b/source/tkd/element/font.d
@@ -1,0 +1,98 @@
+/**
+* Element module.
+*
+* License:
+*     MIT. See LICENSE for full details.
+*/
+module tkd.element.font;
+
+/**
+* Standard supported fonts.
+*/
+enum Font : string {
+	default_ = "",
+	arial = "Arial",
+	courier = "Courier",
+	gothic = "Gothic",
+	helvetica = "Helvetica",
+	symbol = "Symbol",	
+	times = "Times",
+	timesNewRoman = "Times New Roman",             
+}
+
+/**
+* Windows only fonts.
+*/
+version (Windows)
+{
+	enum WindowsFont : string
+	{
+		comicSans = "Comic Sans MS",
+	}
+}
+
+/**
+* Font weight options.
+*/
+enum FontWeight : string {
+	default_ = "",
+	normal = "",
+	bold = "bold",
+}
+
+/**
+* Font style options.
+*/
+enum FontStyle : string {
+	default_ = "",
+	italic = "italic",
+	underline = "underline",
+	overstrike = "overstrike",
+}
+
+/**
+* Font slant options.
+*/
+enum FontSlant : string {
+	default_ = "",
+	normal = "",
+	roman = "",
+	italic = "italic",
+}
+
+/**
+* Font underline options.
+*/
+enum FontUnderline : string {
+	default_ = "",
+	False = "",
+	True = "underline",             
+	no = "",
+	yes = "underline",
+	normal = "",
+	underline = "underline",
+	off = "",
+	on = "underline",
+}
+
+/**
+* Font overstrike options.
+*/
+enum FontOverstrike : string {
+	default_ = "",
+	False = "",
+	True = "overstrike",
+	no = "",
+	yes = "overstrike",
+	normal = "",
+	overstrike = "overstrike",
+	off = "",
+	on = "overstrike",
+}
+
+/**
+* Font size default.
+*/
+enum FontSize : int {
+	default_ = 0,
+}

--- a/source/tkd/element/package.d
+++ b/source/tkd/element/package.d
@@ -8,5 +8,6 @@ module tkd.element;
 
 public import tkd.element.color;
 public import tkd.element.cursor;
+public import tkd.element.font;
 public import tkd.element.elementclass;
 public import tkd.element.uielement;

--- a/source/tkd/widget/combobox.d
+++ b/source/tkd/widget/combobox.d
@@ -199,7 +199,7 @@ class ComboBox : Widget, IXScrollable!(ComboBox)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
-    mixin Color;
+	mixin Color;
 	mixin Cursor;
 	mixin Data;
 	mixin Delete_;

--- a/source/tkd/widget/combobox.d
+++ b/source/tkd/widget/combobox.d
@@ -14,6 +14,7 @@ import std.string;
 import tkd.element.element;
 import tkd.element.uielement;
 import tkd.widget.common.boundingbox;
+import tkd.widget.common.color;
 import tkd.widget.common.cursor;
 import tkd.widget.common.data;
 import tkd.widget.common.delete_;
@@ -198,6 +199,7 @@ class ComboBox : Widget, IXScrollable!(ComboBox)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
+    mixin Color;
 	mixin Cursor;
 	mixin Data;
 	mixin Delete_;

--- a/source/tkd/widget/common/color.d
+++ b/source/tkd/widget/common/color.d
@@ -46,4 +46,22 @@ mixin template Color()
 
 		return cast(T) this;
 	}
+
+	/**
+	 * Set the insert cursor color of the widget.
+	 *
+	 * Params:
+	 *     color = The name of the color 'yellow' or it's hex value '#FFFF00' or '#FF0'.
+	 *
+	 * 	   For a comprehensive list of color names see the tkd.element.color Color enum.
+	 *
+	 * Returns:
+	 *     This widget to aid method chaining.
+	 */
+	public auto setInsertColor(this T)(string color)
+	{
+		this._tk.eval("%s configure -insertbackground %s", this.id, color);
+
+		return cast(T) this;
+	}
 }

--- a/source/tkd/widget/common/color.d
+++ b/source/tkd/widget/common/color.d
@@ -1,0 +1,27 @@
+/**
+ * Color module.
+ *
+ * License:
+ *     MIT. See LICENSE for full details.
+ */
+module tkd.widget.common.color;
+
+/**
+ * These are common commands that apply to all widgets that have them injected.
+ */
+mixin template Color()
+{
+	public auto setForegroundColor(this T)(string color)
+	{
+		this._tk.eval("%s configure -foreground %s", this.id, color);
+
+		return cast(T) this;
+	}
+
+    public auto setBackgroundColor(this T)(string color)
+	{
+		this._tk.eval("%s configure -background %s", this.id, color);
+
+		return cast(T) this;
+	}
+}

--- a/source/tkd/widget/common/color.d
+++ b/source/tkd/widget/common/color.d
@@ -11,6 +11,17 @@ module tkd.widget.common.color;
  */
 mixin template Color()
 {
+	/**
+	 * Set the foreground color of the widget.
+	 *
+	 * Params:
+	 *     color = The name of the color 'black' or its hex value '#000000' or '#000'.
+	 *
+	 * 	   For a comprehensive list of color names see the tkd.element.color Color enum.
+	 *
+	 * Returns:
+	 *     This widget to aid method chaining.
+	 */
 	public auto setForegroundColor(this T)(string color)
 	{
 		this._tk.eval("%s configure -foreground %s", this.id, color);
@@ -18,7 +29,18 @@ mixin template Color()
 		return cast(T) this;
 	}
 
-    public auto setBackgroundColor(this T)(string color)
+	/**
+	 * Set the background color of the widget.
+	 *
+	 * Params:
+	 *     color = The name of the color 'white' or it's hex value '#FFFFFF' or '#FFF'.
+	 *
+	 * 	   For a comprehensive list of color names see the tkd.element.color Color enum.
+	 *
+	 * Returns:
+	 *     This widget to aid method chaining.
+	 */
+	public auto setBackgroundColor(this T)(string color)
 	{
 		this._tk.eval("%s configure -background %s", this.id, color);
 

--- a/source/tkd/widget/common/font.d
+++ b/source/tkd/widget/common/font.d
@@ -11,9 +11,9 @@ module tkd.widget.common.font;
  */
 mixin template Font()
 {  
-	public auto setFont(this T)(string font)
+	public auto setFont(this T)(string font, int size = 12, string bold = "", string italic = "", string underline = "")
 	{
-		this._tk.eval("%s configure -font %s", this.id, font);
+		this._tk.eval("%s configure -font {%s %s %s %s %s}", this.id, font, size, bold, italic, underline);
 
 		return cast(T) this;
 	}

--- a/source/tkd/widget/common/font.d
+++ b/source/tkd/widget/common/font.d
@@ -1,19 +1,41 @@
 /**
- * Font module.
- *
- * License:
- *     MIT. See LICENSE for full details.
- */
+* Font module.
+*
+* License:
+*     MIT. See LICENSE for full details.
+*/
 module tkd.widget.common.font;
 
 /**
- * These are common commands that apply to all widgets that have them injected.
- */
+* These are common commands that apply to all widgets that have them injected.
+*/
 mixin template Font()
 {  
-	public auto setFont(this T)(string font, int size = 0, string bold = "", string italic = "", string underline = "")
+	import tkd.element.font;
+
+	/**
+	 * Set the font and its options for the widget.
+	 *
+	 * Params:
+	 *     font = The name of the font like 'Arial' or 'arial'.
+	 *     size = The size of the font like '12'.
+	 *	   weight = The weight of the font like 'bold'.
+	 *	   slant = The slant of the font like 'italic'.
+	 *     underline = The underline option of the font like 'underline'.
+	 *     overstrike = The overstrike option of the font like 'overstrike'.
+	 *
+	 * 	   For a comprehensive list of fonts and options see the enums in tkd.element.font.
+	 *
+	 *     Calling setFont() without any parameters will reset the font and its options to the defaults.
+	 *
+	 * Returns:
+	 *     This widget to aid method chaining.
+	 */
+	public auto setFont(this T)(string font = Font.default_, int size = FontSize.default_, 
+								string weight = FontWeight.default_, string slant = FontSlant.default_, 
+								string underline = FontUnderline.default_, string overstrike = FontOverstrike.default_)
 	{
-		this._tk.eval("%s configure -font {%s %s %s %s %s}", this.id, font, size, bold, italic, underline);
+		this._tk.eval("%s configure -font {{%s} %s %s %s %s %s}", this.id, font, size, weight, slant, underline, overstrike);
 
 		return cast(T) this;
 	}

--- a/source/tkd/widget/common/font.d
+++ b/source/tkd/widget/common/font.d
@@ -1,0 +1,20 @@
+/**
+ * Font module.
+ *
+ * License:
+ *     MIT. See LICENSE for full details.
+ */
+module tkd.widget.common.font;
+
+/**
+ * These are common commands that apply to all widgets that have them injected.
+ */
+mixin template Font()
+{  
+	public auto setFont(this T)(string font)
+	{
+		this._tk.eval("%s configure -font %s", this.id, font);
+
+		return cast(T) this;
+	}
+}

--- a/source/tkd/widget/common/font.d
+++ b/source/tkd/widget/common/font.d
@@ -11,7 +11,7 @@ module tkd.widget.common.font;
  */
 mixin template Font()
 {  
-	public auto setFont(this T)(string font, int size = 12, string bold = "", string italic = "", string underline = "")
+	public auto setFont(this T)(string font, int size = 0, string bold = "", string italic = "", string underline = "")
 	{
 		this._tk.eval("%s configure -font {%s %s %s %s %s}", this.id, font, size, bold, italic, underline);
 

--- a/source/tkd/widget/entry.d
+++ b/source/tkd/widget/entry.d
@@ -12,6 +12,7 @@ module tkd.widget.entry;
 import std.string;
 import tkd.element.uielement;
 import tkd.widget.common.boundingbox;
+import tkd.widget.common.color;
 import tkd.widget.common.cursor;
 import tkd.widget.common.delete_;
 import tkd.widget.common.exportselection;
@@ -153,6 +154,7 @@ class Entry : Widget, IXScrollable!(Entry)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
+    mixin Color;
 	mixin Cursor;
 	mixin Delete_;
 	mixin ExportSelection;

--- a/source/tkd/widget/entry.d
+++ b/source/tkd/widget/entry.d
@@ -154,7 +154,7 @@ class Entry : Widget, IXScrollable!(Entry)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
-    mixin Color;
+	mixin Color;
 	mixin Cursor;
 	mixin Delete_;
 	mixin ExportSelection;

--- a/source/tkd/widget/label.d
+++ b/source/tkd/widget/label.d
@@ -11,6 +11,7 @@ module tkd.widget.label;
  */
 import tkd.element.uielement;
 import tkd.widget.common.anchor;
+import tkd.widget.common.color;
 import tkd.widget.common.justify;
 import tkd.widget.common.padding;
 import tkd.widget.common.relief;
@@ -86,6 +87,7 @@ class Label : TextWidget
 	 * Mixin common commands.
 	 */
 	mixin Anchor;
+	mixin Color;
 	mixin Justify;
 	mixin Padding;
 	mixin Relief;

--- a/source/tkd/widget/spinbox.d
+++ b/source/tkd/widget/spinbox.d
@@ -12,6 +12,7 @@ module tkd.widget.spinbox;
 import std.string;
 import tkd.element.uielement;
 import tkd.widget.common.boundingbox;
+import tkd.widget.common.color;
 import tkd.widget.common.command;
 import tkd.widget.common.cursor;
 import tkd.widget.common.data;
@@ -233,6 +234,7 @@ class SpinBox : Widget, IXScrollable!(SpinBox)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
+    mixin Color;
 	mixin Command;
 	mixin Cursor;
 	mixin Data;

--- a/source/tkd/widget/spinbox.d
+++ b/source/tkd/widget/spinbox.d
@@ -234,7 +234,7 @@ class SpinBox : Widget, IXScrollable!(SpinBox)
 	 * Mixin common commands.
 	 */
 	mixin BoundingBox;
-    mixin Color;
+	mixin Color;
 	mixin Command;
 	mixin Cursor;
 	mixin Data;

--- a/source/tkd/widget/text.d
+++ b/source/tkd/widget/text.d
@@ -13,6 +13,7 @@ import std.conv;
 import tkd.element.uielement;
 import tkd.image.image;
 import tkd.widget.common.border;
+import tkd.widget.common.color;
 import tkd.widget.common.height;
 import tkd.widget.common.relief;
 import tkd.widget.common.width;
@@ -494,6 +495,7 @@ class Text : Widget, IXScrollable!(Text), IYScrollable!(Text)
 	 * Mixin common commands.
 	 */
 	mixin Border;
+	mixin Color;
 	mixin Height;
 	mixin Relief;
 	mixin Width;

--- a/source/tkd/widget/text.d
+++ b/source/tkd/widget/text.d
@@ -14,6 +14,7 @@ import tkd.element.uielement;
 import tkd.image.image;
 import tkd.widget.common.border;
 import tkd.widget.common.color;
+import tkd.widget.common.font;
 import tkd.widget.common.height;
 import tkd.widget.common.relief;
 import tkd.widget.common.width;
@@ -496,6 +497,7 @@ class Text : Widget, IXScrollable!(Text), IYScrollable!(Text)
 	 */
 	mixin Border;
 	mixin Color;
+    mixin Font;
 	mixin Height;
 	mixin Relief;
 	mixin Width;

--- a/source/tkd/widget/text.d
+++ b/source/tkd/widget/text.d
@@ -497,7 +497,7 @@ class Text : Widget, IXScrollable!(Text), IYScrollable!(Text)
 	 */
 	mixin Border;
 	mixin Color;
-    mixin Font;
+	mixin Font;
 	mixin Height;
 	mixin Relief;
 	mixin Width;

--- a/source/tkd/window/window.d
+++ b/source/tkd/window/window.d
@@ -13,6 +13,7 @@ import std.conv;
 import std.string;
 import tkd.element.element : CommandCallback;
 import tkd.element.uielement;
+import tkd.widget.common.color;
 import tkd.image.image;
 import tkd.interpreter;
 
@@ -596,6 +597,8 @@ class Window : UiElement
 
 		return this._mainWindow;
 	}
+    
+    mixin Color;
 }
 
 /**

--- a/source/tkd/window/window.d
+++ b/source/tkd/window/window.d
@@ -597,8 +597,11 @@ class Window : UiElement
 
 		return this._mainWindow;
 	}
-    
-    mixin Color;
+
+	/**
+	 * Mixin common commands.
+	 */
+	mixin Color;
 }
 
 /**


### PR DESCRIPTION
new mixin template that allows you to set the foreground and background color for some of the widgets, changed example.d to reflect this